### PR TITLE
Support for multi image cards in frontend and backend

### DIFF
--- a/backend/main/server/api.py
+++ b/backend/main/server/api.py
@@ -4,7 +4,7 @@ from flask_restful import Api
 from main.server.resources.Message import MessageListResource, MessageResource, MessageListRangeResource, MessageCount
 from main.server.resources.Game import GameCount, GameListResource
 from main.server.resources.Gallery import GalleryCount, GalleryListResource
-from main.server.resources.Multigallery import MultiGalleryCount, MultiGalleryListResource, MultiGalleryListAllResource
+from main.server.resources.Multigallery import MultiGalleryCount, MultiGalleryListResource
 from main.server.resources.Video import VideoCount, VideoListResource
 from main.server.resources.Announcement import AnnouncementListResource, AnnouncementCount
 

--- a/backend/main/server/api.py
+++ b/backend/main/server/api.py
@@ -4,6 +4,7 @@ from flask_restful import Api
 from main.server.resources.Message import MessageListResource, MessageResource, MessageListRangeResource, MessageCount
 from main.server.resources.Game import GameCount, GameListResource
 from main.server.resources.Gallery import GalleryCount, GalleryListResource
+from main.server.resources.Multigallery import MultiGalleryCount, MultiGalleryListResource, MultiGalleryListAllResource
 from main.server.resources.Video import VideoCount, VideoListResource
 from main.server.resources.Announcement import AnnouncementListResource, AnnouncementCount
 
@@ -26,6 +27,10 @@ api.add_resource(GameCount, '/games/count')
 # Gallery
 api.add_resource(GalleryListResource, '/gallery')
 api.add_resource(GalleryCount, '/gallery/count')
+
+# Gallery with with secondary key to group art together
+api.add_resource(MultiGalleryListResource, '/multigallery')
+api.add_resource(MultiGalleryCount, '/multigallery/count')
 
 # Videos
 api.add_resource(VideoListResource, '/videos')

--- a/backend/main/server/models.py
+++ b/backend/main/server/models.py
@@ -133,11 +133,9 @@ class MultiGallery(db.Model):
 
     def __init__(
             self,
-            artworkID,
             setID,
             artworkLink,
     ):
-        self.artworkID = artworkID
         self.setID = setID
         self.artworkLink = artworkLink
 
@@ -147,37 +145,40 @@ class SetMetadata(db.Model):
     metadataID = db.Column(db.Integer, primary_key=True, autoincrement=True)
     setID = db.Column(db.String(32), nullable=False)
     artistLink = db.Column(db.String(2048), nullable=True)
-    username = db.Column(db.String(64), nullable=True)
+    username = db.Column(db.String(64), nullable=False)
     title = db.Column(db.String(64), nullable=True)
 
     def __init__(
             self,
-            metadataID,
             setID,
             username,
             title,
             artistLink,
     ):
-        self.metadataID = metadataID
         self.setID = setID
         self.artistLink = artistLink
         self.username = username
         self.title = title
 
-# TODO write setmetadata model
-
-
-# TODO: Write an incoming multigallery schema for validation purposes
-
 
 class SetMetadataSchema(ma.Schema):
     metadataID = fields.Integer()
-    setID = fields.String(required=False)
+    setID = fields.String(required=True)
     artistLink = fields.String(required=False)
     username = fields.String(required=True)
     title = fields.String(required=False)
 
 
 class MultiGallerySchema(ma.Schema):
+    artworkID = fields.Integer()
     metadata = fields.Nested(SetMetadataSchema)
     gallery = fields.List(fields.String(required=True))
+
+
+class MultiGalleryImportSchema(ma.Schema):
+    metadataID = fields.Integer()
+    setID = fields.String(required=True)
+    artworkLink = fields.String(required=True)
+    artistLink = fields.String(required=False)
+    username = fields.String(required=True)
+    title = fields.String(required=False)

--- a/backend/main/server/models.py
+++ b/backend/main/server/models.py
@@ -121,3 +121,35 @@ class VideoSchema(ma.Schema):
     artistLink = fields.String(required=False)
     username = fields.String(required=True)
     title = fields.String(required=False)
+
+
+class MultiGallery(db.Model):
+    __tablename__ = 'MULTIGALLERY'
+    artworkID = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    setID = db.Column(db.String(16), nullable=False)
+    artworkLink = db.Column(db.String(2048), nullable=False)
+    artistLink = db.Column(db.String(2048), nullable=True)
+    username = db.Column(db.String(64), nullable=True)
+    title = db.Column(db.String(64), nullable=True)
+
+    def __init__(
+            self,
+            artworkID,
+            setID,
+            artworkLink,
+            username,
+            title,
+            artistLink,
+    ):
+        self.artworkID = artworkID
+        self.setID = setID
+        self.artworkLink = artworkLink
+        self.artistLink = artistLink
+        self.username = username
+        self.title = title
+
+
+class MultiGallerySchema(ma.Schema):
+    setID = fields.Integer()
+    gallery = fields.List(fields.Nested(
+        lambda: GallerySchema()))

--- a/backend/main/server/models.py
+++ b/backend/main/server/models.py
@@ -127,31 +127,57 @@ class VideoSchema(ma.Schema):
 class MultiGallery(db.Model):
     __tablename__ = 'MULTIGALLERY'
     artworkID = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    setID = db.Column(db.String(16), nullable=False)
+    setID = db.Column(db.Integer, db.ForeignKey('SETMETADATA.setID'), nullable=False)
+    setmetadata = db.relationship("SetMetadata")
     artworkLink = db.Column(db.String(2048), nullable=False)
-    artistLink = db.Column(db.String(2048), nullable=True)
-    username = db.Column(db.String(64), nullable=True)
-    title = db.Column(db.String(64), nullable=True)
 
     def __init__(
             self,
             artworkID,
             setID,
             artworkLink,
-            username,
-            title,
-            artistLink,
     ):
         self.artworkID = artworkID
         self.setID = setID
         self.artworkLink = artworkLink
+
+
+class SetMetadata(db.Model):
+    __tablename__ = 'SETMETADATA'
+    metadataID = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    setID = db.Column(db.String(32), nullable=False)
+    artistLink = db.Column(db.String(2048), nullable=True)
+    username = db.Column(db.String(64), nullable=True)
+    title = db.Column(db.String(64), nullable=True)
+
+    def __init__(
+            self,
+            metadataID,
+            setID,
+            username,
+            title,
+            artistLink,
+    ):
+        self.metadataID = metadataID
+        self.setID = setID
         self.artistLink = artistLink
         self.username = username
         self.title = title
 
+# TODO write setmetadata model
 
-# TODO add Message + translated message
+
+# TODO: Write an incoming multigallery schema for validation purposes
+
+
+class SetMetadataSchema(ma.Schema):
+    metadataID = fields.Integer()
+    setID = fields.String(required=False)
+    artistLink = fields.String(required=False)
+    username = fields.String(required=True)
+    title = fields.String(required=False)
+
+
 class MultiGallerySchema(ma.Schema):
-    setID = fields.Integer()
-    gallery = fields.List(fields.Nested(
-        lambda: GallerySchema()))
+    metadata = fields.Nested(SetMetadataSchema)
+    gallery = fields.List(fields.String(required=True))

--- a/backend/main/server/models.py
+++ b/backend/main/server/models.py
@@ -123,6 +123,7 @@ class VideoSchema(ma.Schema):
     title = fields.String(required=False)
 
 
+# TODO add Message + translated message
 class MultiGallery(db.Model):
     __tablename__ = 'MULTIGALLERY'
     artworkID = db.Column(db.Integer, primary_key=True, autoincrement=True)
@@ -149,6 +150,7 @@ class MultiGallery(db.Model):
         self.title = title
 
 
+# TODO add Message + translated message
 class MultiGallerySchema(ma.Schema):
     setID = fields.Integer()
     gallery = fields.List(fields.Nested(

--- a/backend/main/server/resources/Multigallery.py
+++ b/backend/main/server/resources/Multigallery.py
@@ -1,0 +1,89 @@
+from flask_restful import Resource
+from flask import request
+from main.server import db, cache, app
+from main.server.models import MultiGallery, MultiGallerySchema
+from flask_jwt import jwt_required
+
+artwork_schema = MultiGallerySchema()
+gallery_schema = MultiGallerySchema(many=True)
+
+
+@app.after_request
+def add_header(response):
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    response.headers['Access-Control-Allow-Credentials'] = 'true'
+    response.headers['Access-Control-Allow-Methods'] = 'GET,POST'
+    response.headers[
+        'Access-Control-Allow-Headers'] = 'Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers'
+    return response
+
+
+class MultiGalleryCount(Resource):
+    @cache.cached(timeout=100)
+    def get(self):
+        """Gets the number of messages available on the server"""
+        return {'status': 'success', 'count': MultiGallery.query.count()}, 200
+
+
+class MultiGalleryListResource(Resource):
+    @cache.cached(timeout=100)
+    def get(self):
+        """Gets all Artwork on the server ordered by set id"""
+        multigallery = MultiGallery.query.all()
+
+        if not multigallery:
+            return {
+                'status': 'success',
+                'multigallery': {}
+            }, 206  # Partial Content Served, the other status code never loads
+
+        # Create a map of {set_id: [art1, art2,...]}
+        set_map = {}
+        for artwork in multigallery:
+            if artwork.setID not in set_map:
+                set_map[artwork.setID] = [artwork]
+                continue
+            set_map[artwork.setID].append(artwork)
+        gallery_list = [
+            {"setID": set_id, "gallery": artworks}
+            for set_id, artworks in set_map.items()
+        ]
+
+        multigallery_json = gallery_schema.dump(gallery_list)
+        return {'status': 'success', 'multigallery': multigallery_json}, 200
+
+    @jwt_required()
+    def post(self):
+        """Add Artwork"""
+        json_data = request.get_json(force=True)
+
+        if not json_data:
+            return {'status': 'fail', 'message': 'No input data'}, 400
+
+        errors = artwork_schema.validate(json_data)
+
+        if errors:
+            return {'status': 'fail', 'message': 'Error handling request'}, 422
+
+        data = artwork_schema.load(json_data)
+
+        entry = MultiGallery.query.filter_by(
+            artworkLink=data.get('artworkLink')).first()
+
+        if entry:
+            return {'status': 'fail', 'message': 'Artwork already exists'}, 400
+
+        entry = MultiGallery(
+            setId=data.get('setId'),
+            artworkLink=data.get('artworkLink'),
+            artistLink=data.get('artistLink'),
+            username=data.get('username'),
+            title=data.get('title'))
+
+        db.session.add(entry)
+        db.session.commit()
+
+        return {
+            'status': 'success',
+            'message': 'Artwork entry successfully created'
+        }, 201

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "react-scripts": "^4.0.1",
     "react-visibility-sensor": "^5.1.1",
     "rxjs": "^6.6.3",
+    "seedrandom": "^3.0.5",
     "typescript": "^4.1.2"
   },
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "@types/react-dom": "^17.0.3",
     "@types/react-router-dom": "^5.1.6",
     "@types/react-transition-group": "^4.4.0",
+    "@types/seedrandom": "^3.0.0",
     "bootstrap": "^4.5.3",
     "classnames": "^2.2.6",
     "cra-template-typescript": "^1.1.1",
@@ -26,7 +27,6 @@
     "react-scripts": "^4.0.1",
     "react-visibility-sensor": "^5.1.1",
     "rxjs": "^6.6.3",
-    "seedrandom": "^3.0.5",
     "typescript": "^4.1.2"
   },
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react-scripts": "^4.0.1",
     "react-visibility-sensor": "^5.1.1",
     "rxjs": "^6.6.3",
+    "seedrandom": "^3.0.5",
     "typescript": "^4.1.2"
   },
   "scripts": {

--- a/frontend/src/components/comboSection/comboSection.tsx
+++ b/frontend/src/components/comboSection/comboSection.tsx
@@ -22,7 +22,6 @@ interface ComboSectionState extends BaseSectionState {
 export default class ComboSection extends BaseSection<Message|Artwork|Video|MultiArtwork> {
 
     renderCard(object: (Message|Artwork|Video|MultiArtwork), cardStyleNum: number, language: DisplayedLanguage, id: number): JSX.Element {
-        // TODO: messagecard-center might not used or needed
         if ("messageID" in object) {
             return (
                 <div className="card-section">

--- a/frontend/src/components/comboSection/comboSection.tsx
+++ b/frontend/src/components/comboSection/comboSection.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import {Artwork} from '../../models/artwork';
+import {Artwork, MultiArtwork} from '../../models/artwork';
 import {Message} from "../../models/message";
 import {Video} from "../../models/video";
 import DisplayedLanguage from "../../models/language";
 import ArtworkCard from '../gallery/artworkCard/artworkCard';
+import MultiArtworkCard from '../gallery/artworkCard/multiArtworkCard';
 import VideoCard from '../videoSection/videoCard';
 import MessageCard from "../messageSection/messageCard/messageCard";
 import BaseSection, {BaseSectionProps, BaseSectionState} from "../../shared/components/baseSection/baseSection";
@@ -18,9 +19,9 @@ interface ComboSectionState extends BaseSectionState {
 
 }
 
-export default class ComboSection extends BaseSection<Message|Artwork|Video> {
+export default class ComboSection extends BaseSection<Message|Artwork|Video|MultiArtwork> {
 
-    renderCard(object: (Message|Artwork|Video), cardStyleNum: number, language: DisplayedLanguage, id: number): JSX.Element {
+    renderCard(object: (Message|Artwork|Video|MultiArtwork), cardStyleNum: number, language: DisplayedLanguage, id: number): JSX.Element {
         // TODO: messagecard-center might not used or needed
         if ("messageID" in object) {
             return (
@@ -38,6 +39,12 @@ export default class ComboSection extends BaseSection<Message|Artwork|Video> {
             return (
                 <div className="card-section">
                     <VideoCard key={object.videoID} object={object} cardStyleNum={id % CardStyleLength}/>
+                </div>
+            );
+        } else if ("gallery" in object && "metadata" in object) {
+            return (
+                <div className="card-section">
+                    <MultiArtworkCard key={object.metadata.metadataID} object={object} cardStyleNum={id % CardStyleLength}/>
                 </div>
             );
         }

--- a/frontend/src/components/gallery/artworkCard/multiArtworkCard.tsx
+++ b/frontend/src/components/gallery/artworkCard/multiArtworkCard.tsx
@@ -1,0 +1,95 @@
+import BaseCard, { BaseCardProps, BaseCardState } from "../../../shared/components/baseCard/baseCard";
+import classNames from 'classnames';
+import DisplayedLanguage from "../../../models/language";
+import handleViewport from 'react-in-viewport';
+import { MultiArtwork, ArtworkMetadata } from '../../../models/artwork';
+import './artworkCard.css';
+import { linkToString } from '../../../models/url';
+
+enum ImageLoadingState {
+    NotLoaded,
+    Loading,
+    Loaded,
+}
+
+interface MultiArtworkCardProps extends BaseCardProps<MultiArtwork> {
+}
+
+interface MultiArtworkCardState extends BaseCardState {
+    loadingState: ImageLoadingState,
+}
+
+export default class MultiArtworkCard extends BaseCard<MultiArtwork, MultiArtworkCardProps, MultiArtworkCardState> {
+    private readonly artworks: string[];
+    private readonly metadata: ArtworkMetadata;
+    private readonly username: string;
+    private imageElement: HTMLImageElement;
+
+    constructor(props: MultiArtworkCardProps) {
+        super(props);
+        this.artworks = props.object.gallery;
+        this.metadata = props.object.metadata;
+        this.username = this.metadata.username ? props.object.metadata.username : "Anonymous";
+        this.imageElement = document.createElement("img");
+
+        this.imageLoaded = this.imageLoaded.bind(this);
+    }
+
+    state: MultiArtworkCardState = {
+        loadingState: ImageLoadingState.NotLoaded,
+        inViewport: false // From BaseCardState
+    }
+
+    private imageLoaded() {
+        this.setState({
+            loadingState: ImageLoadingState.Loaded,
+        });
+
+        this.imageElement.removeEventListener("load", this.imageLoaded);
+    }
+
+    private setImage() {
+        if (this.state.loadingState === ImageLoadingState.NotLoaded) {
+            // TODO: we need to iterate though this
+            this.imageElement.src = this.artworks[0];
+            this.imageElement.addEventListener("load", this.imageLoaded);
+
+            this.setState({
+                loadingState: ImageLoadingState.Loading,
+            });
+        }
+    }
+
+    componentDidMount() {
+        this.setImage();
+    }
+
+    componentDidUpdate() {
+        this.setImage();
+    }
+
+    renderArtwork() {
+        const hasLoaded = this.state.loadingState === ImageLoadingState.Loaded;
+        // TODO: we need to iterate though this
+        const artworkLink = this.artworks[0];
+        const artistLink = this.metadata.artistLink ? linkToString(this.metadata.artistLink) : "#no_artist_link";
+
+        return (
+            <div className="artwork-card">
+                <img className="artwork-card-img" src={artworkLink} alt={this.metadata.title} />
+                <div className="artwork-card-footer">
+                    <div className="title">{this.metadata.title}</div>
+                    <p>
+                        <div className="artist">
+                            Artist: <a href={artistLink}>{this.username}</a>
+                        </div>
+                    </p>
+                </div>
+            </div>
+        )
+    }
+
+    render() {
+        return this.renderCard(this.renderArtwork());
+    }
+}

--- a/frontend/src/components/gallery/artworkCard/multiArtworkCard.tsx
+++ b/frontend/src/components/gallery/artworkCard/multiArtworkCard.tsx
@@ -50,7 +50,6 @@ export default class MultiArtworkCard extends BaseCard<MultiArtwork, MultiArtwor
 
     private setImage() {
         if (this.state.loadingState === ImageLoadingState.NotLoaded) {
-            // TODO: we need to iterate though this
             this.imageElement.src = this.artworks[0];
             this.imageElement.addEventListener("load", this.imageLoaded);
 
@@ -70,13 +69,15 @@ export default class MultiArtworkCard extends BaseCard<MultiArtwork, MultiArtwor
 
     renderArtwork() {
         const hasLoaded = this.state.loadingState === ImageLoadingState.Loaded;
-        // TODO: we need to iterate though this
-        const artworkLink = this.artworks[0];
         const artistLink = this.metadata.artistLink ? linkToString(this.metadata.artistLink) : "#no_artist_link";
 
         return (
             <div className="artwork-card">
-                <img className="artwork-card-img" src={artworkLink} alt={this.metadata.title} />
+                {this.artworks.map((obj, idx) => {
+                    return (
+                        <img className="artwork-card-img" src={obj} alt={this.metadata.title} />
+                    );
+                })}
                 <div className="artwork-card-footer">
                     <div className="title">{this.metadata.title}</div>
                     <p>

--- a/frontend/src/components/gallery/multiGallerySection.tsx
+++ b/frontend/src/components/gallery/multiGallerySection.tsx
@@ -1,0 +1,25 @@
+import { MultiArtwork } from '../../models/artwork';
+import MultiArtworkCard from './artworkCard/multiArtworkCard';
+import DisplayedLanguage from "../../models/language";
+import BaseSection, {BaseSectionProps, BaseSectionState} from "../../shared/components/baseSection/baseSection";
+import { CardStyleLength } from "../../shared/components/baseCard/baseCard";
+import './gallerySection.css';
+
+interface MultiGallerySectionProps extends BaseSectionProps<MultiArtwork> {
+}
+
+interface MultiGallerySectionState extends BaseSectionState {
+
+}
+
+
+export default class MultiGallerySection extends BaseSection<MultiArtwork> {
+    renderCard(object: MultiArtwork, cardStyleNum: number, language: DisplayedLanguage, id: number): JSX.Element {
+        return (
+            // TODO: edit gallery-section to display at a specific scale
+            <div className="gallery-section">
+                <MultiArtworkCard key={object.metadata.metadataID} object={object} cardStyleNum={id % CardStyleLength}/>
+            </div>
+        );
+    }
+}

--- a/frontend/src/controllers/mano-aloe.service.ts
+++ b/frontend/src/controllers/mano-aloe.service.ts
@@ -1,6 +1,6 @@
 import {Message, messageFromJson} from "../models/message";
-import {CountResponse, GalleryResponse, MessageResponse, ArchiveResponse, AnnouncementResponse, VideoResponse} from "../models/response";
-import {Artwork, artworkFromJson} from "../models/artwork";
+import {CountResponse, GalleryResponse, MultiGalleryResponse, MessageResponse, ArchiveResponse, AnnouncementResponse, VideoResponse} from "../models/response";
+import {Artwork, MultiArtwork, artworkFromJson, multiArtworkFromJson} from "../models/artwork";
 import {Archive, archiveFromJson} from "../models/archive";
 import {Announcement, announcementFromJson} from "../models/announcement";
 import {Video, videoFromJson} from "../models/video";
@@ -86,6 +86,18 @@ export default class ManoAloeService {
         return this.getCount('gallery');
     }
 
+    public getMultiGallery(): Promise<MultiArtwork[]> {
+        return fetch(this.apiURL + 'multigallery')
+            .then((res: { json: () => any; }) => {
+                return res.json();
+            })
+            .then((apiResponse: MultiGalleryResponse) => {
+                return apiResponse.multigallery.map(multiArtworkFromJson);
+            })
+            .catch((error: Error) => {
+                throw error;
+            })
+    }
 
     public getVideo(): Promise<Video[]> {
         return fetch(this.apiURL + 'videos')

--- a/frontend/src/models/artwork.ts
+++ b/frontend/src/models/artwork.ts
@@ -16,6 +16,23 @@ export interface ArtworkJson {
     title: string;
 }
 
+export interface MultiArtwork {
+    setID: string;
+    gallery: Artwork[];
+}
+
+export interface MultiArtworkJson {
+    setID: string;
+    gallery: Artwork[];
+    // gallery:Array<{
+    //     artworkID: number;
+    //     artworkLink: string;
+    //     artistLink: string;
+    //     username: string;
+    //     title: string;
+    // }>;
+}
+
 export function artworkFromJson(json: ArtworkJson): Artwork {
     const { artworkID, artworkLink, artistLink, username, title } = json;
     return {
@@ -37,3 +54,27 @@ export function artworkToJson(artwork: Artwork): ArtworkJson {
         title,
     }
 }
+
+export function multiArtworkFromJson(json: MultiArtworkJson): MultiArtwork {
+    const setID = json["setID"];
+    const jsonGallery = json["gallery"];
+    let artworkGallery: Artwork[] = [];
+    for (var art of jsonGallery) {
+        artworkGallery.push(art);
+    }
+    return {
+        setID,
+        gallery: artworkGallery,
+    }
+}
+
+// TODO: Does this need fixing...?
+export function multiArtworkToJson(artwork: MultiArtwork): MultiArtworkJson {
+    const setID = artwork.setID;
+    const gallery = artwork.gallery;
+    return {
+        setID,
+        gallery,
+    }
+}
+

--- a/frontend/src/models/artwork.ts
+++ b/frontend/src/models/artwork.ts
@@ -16,21 +16,30 @@ export interface ArtworkJson {
     title: string;
 }
 
-export interface MultiArtwork {
+export interface ArtworkMetadata {
+    metadataID: number;
     setID: string;
-    gallery: Artwork[];
+    artistLink: ExternalLink;
+    username: string;
+    title: string;    
+}
+
+export interface ArtworkMetadataJson {
+    metadataID: number;
+    setID: string;
+    artistLink: string;
+    username: string;
+    title: string;    
+}
+
+export interface MultiArtwork {
+    metadata: ArtworkMetadata;
+    gallery: Array<string>;
 }
 
 export interface MultiArtworkJson {
-    setID: string;
-    gallery: Artwork[];
-    // gallery:Array<{
-    //     artworkID: number;
-    //     artworkLink: string;
-    //     artistLink: string;
-    //     username: string;
-    //     title: string;
-    // }>;
+    metadata: ArtworkMetadata;
+    gallery: Array<string>;
 }
 
 export function artworkFromJson(json: ArtworkJson): Artwork {
@@ -56,24 +65,18 @@ export function artworkToJson(artwork: Artwork): ArtworkJson {
 }
 
 export function multiArtworkFromJson(json: MultiArtworkJson): MultiArtwork {
-    const setID = json["setID"];
-    const jsonGallery = json["gallery"];
-    let artworkGallery: Artwork[] = [];
-    for (var art of jsonGallery) {
-        artworkGallery.push(art);
-    }
+    const { metadata, gallery } = json;
     return {
-        setID,
-        gallery: artworkGallery,
+        metadata,
+        gallery,
     }
 }
 
 // TODO: Does this need fixing...?
 export function multiArtworkToJson(artwork: MultiArtwork): MultiArtworkJson {
-    const setID = artwork.setID;
-    const gallery = artwork.gallery;
+    const { metadata, gallery } = artwork;
     return {
-        setID,
+        metadata,
         gallery,
     }
 }

--- a/frontend/src/models/response.ts
+++ b/frontend/src/models/response.ts
@@ -1,5 +1,5 @@
 import {MessageJson} from "./message";
-import {ArtworkJson} from "./artwork";
+import {ArtworkJson, MultiArtworkJson} from "./artwork";
 import {ArchiveJson} from "./archive";
 import {AnnouncementJson} from "./announcement";
 import {VideoJson} from "./video";
@@ -14,6 +14,10 @@ export interface MessageResponse extends BaseResponse {
 
 export interface GalleryResponse extends BaseResponse {
     gallery: ArtworkJson[];
+}
+
+export interface MultiGalleryResponse extends BaseResponse {
+    multigallery: MultiArtworkJson[];
 }
 
 export interface VideoResponse extends BaseResponse {

--- a/frontend/src/pages/home/home.tsx
+++ b/frontend/src/pages/home/home.tsx
@@ -9,7 +9,7 @@ import SessionService from "../../services/session.service";
 import AnchorLink from 'react-anchor-link-smooth-scroll';
 import ArrowDropDownCircleOutlinedIcon from '@material-ui/icons/ArrowDropDownCircleOutlined';
 import {Announcement} from "../../models/announcement"
-import {Artwork} from "../../models/artwork"
+import {Artwork, MultiArtwork} from "../../models/artwork"
 import {Video} from "../../models/video"
 import './home.css';
 import '../../shared/globalStyles/global.css'
@@ -38,6 +38,7 @@ export interface HomePageState {
     messages: Message[];
     announcements: Announcement[];
     artworks: Artwork[];
+    multiArtworks: MultiArtwork[];
     videos: Video[];
 }
 
@@ -74,6 +75,7 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
         announcements: [],
         artworks: [],
         videos: [],
+        multiArtworks: [],
     }
 
     componentDidMount() {
@@ -102,6 +104,7 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
             .catch((error: Error) => {
                 console.error(error);
             });
+
         const cachedArtworks: Artwork[] | null = SessionService.getGallery();
         if (cachedArtworks && cachedArtworks.length) {
             this.setState({artloading: false, artworks: cachedArtworks});
@@ -115,6 +118,7 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
                     console.error(error);
                 })
         }
+
         const cachedVideos: Video[] | null = SessionService.getVideo();
         if (cachedVideos && cachedVideos.length) {
             this.setState({videos: cachedVideos});
@@ -123,6 +127,21 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
                 .then((videos: Video[]) => {
                     SessionService.saveVideo(videos);
                     this.setState({videos});
+                })
+                .catch((error: Error) => {
+                    console.error(error);
+                })
+        }
+
+        // Gallery with multiple images
+        const cachedMultiGallery: MultiArtwork[] | null = SessionService.getMultiGallery();
+        if (cachedMultiGallery && cachedMultiGallery.length) {
+            this.setState({multiArtworks: cachedMultiGallery});
+        } else {
+            this.manoAloeService.getMultiGallery()
+                .then((multiArtworks: MultiArtwork[]) => {
+                    SessionService.saveMultiGallery(multiArtworks);
+                    this.setState({multiArtworks});
                 })
                 .catch((error: Error) => {
                     console.error(error);
@@ -141,6 +160,8 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
     }
 
     compileCardData() {
+        console.log(this.state.multiArtworks)
+
         // We do this because state setting is async and trying to create this in getData yields empty arrays
         let comboCardData: (Message|Artwork|Video)[] = [];
         // TODO: This can should be more generalized, but generally there will be fewer art than messages

--- a/frontend/src/pages/home/home.tsx
+++ b/frontend/src/pages/home/home.tsx
@@ -149,7 +149,7 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
         }
     }
 
-    renderCardSection(data: (Message|Artwork|Video)[]) {
+    renderCardSection(data: (Message|Artwork|Video|MultiArtwork)[]) {
         return (
             <div>
                 <div className="wrapper-overlay">
@@ -160,17 +160,20 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
     }
 
     compileCardData() {
-        console.log(this.state.multiArtworks)
 
         // We do this because state setting is async and trying to create this in getData yields empty arrays
-        let comboCardData: (Message|Artwork|Video)[] = [];
+        let comboCardData: (Message|Artwork|Video|MultiArtwork)[] = [];
         // TODO: This can should be more generalized, but generally there will be fewer art than messages
         const art_cards_length = this.state.artworks.length;
         const message_cards_length = this.state.messages.length;
         const video_cards_length = this.state.videos.length;
+        const multi_art_cards_length = this.state.multiArtworks.length;
         const index_increment_spacing = Math.floor(message_cards_length/art_cards_length);
 
-        for (let msg_index = 0, art_index = 0, video_index = 0; msg_index < message_cards_length; msg_index++) {
+        for (let multi_art_index = 0; multi_art_index < multi_art_cards_length; multi_art_index++) {
+            comboCardData.push(this.state.multiArtworks[multi_art_index]);
+        }
+        for (let msg_index = 0, art_index = 0, video_index = 0, multi_art_index = 0; msg_index < message_cards_length; msg_index++) {
             comboCardData.push(this.state.messages[msg_index]);
             if (art_index < art_cards_length && msg_index % index_increment_spacing === 0) {
                 comboCardData.push(this.state.artworks[art_index]);

--- a/frontend/src/services/session.service.ts
+++ b/frontend/src/services/session.service.ts
@@ -1,5 +1,5 @@
 import {Message, MessageJson, messageFromJson, messageToJson} from "../models/message";
-import {Artwork, ArtworkJson, artworkFromJson, artworkToJson} from "../models/artwork";
+import {Artwork, ArtworkJson, artworkFromJson, artworkToJson, MultiArtwork, MultiArtworkJson, multiArtworkFromJson, multiArtworkToJson} from "../models/artwork";
 import {Archive, ArchiveJson, archiveFromJson, archiveToJson} from "../models/archive";
 import {Video, VideoJson, videoFromJson, videoToJson} from "../models/video";
 import DisplayedLanguage from "../models/language";
@@ -63,6 +63,17 @@ export default class SessionService {
     public static getGallery(): Artwork[] | null {
         let artworks = SessionService.getFromCache<ArtworkJson[]>('gallery');
         return artworks?.map(artworkFromJson) ?? null;
+    }
+
+
+    public static saveMultiGallery(gallery: MultiArtwork[]): void {
+        let json = gallery.map(multiArtworkToJson);
+        SessionService.saveInCache<MultiArtworkJson[]>('gallery', json);
+    }
+
+    public static getMultiGallery(): MultiArtwork[] | null {
+        let artworks = SessionService.getFromCache<MultiArtworkJson[]>('gallery');
+        return artworks?.map(multiArtworkFromJson) ?? null;
     }
 
 


### PR DESCRIPTION
There's a lot going on in this PR. Addresses #34 

- Add backend support for cards with multiple pictures
- Add frontend support to process cards with multiple pictures (currently just drops all the images into the same card as different img tags, one following the other)
- Refactor how card data is compiled for rendering on home for comboSection

I did not implement image carousel or anything since this PR is already bloated enough.

To pull this over to the aqua side needs rebasing, but it shouldn't be that much work.